### PR TITLE
fix: use reload to avoid downtime

### DIFF
--- a/ansible-scripts/maintenance/update_boot_ssl.yml
+++ b/ansible-scripts/maintenance/update_boot_ssl.yml
@@ -25,5 +25,5 @@
   remote_user: ansible
   become: yes
   tasks:
-    - name: Restart haproxy
+    - name: Reload haproxy
       service: name=haproxy state=reloaded

--- a/ansible-scripts/maintenance/update_ibp_ssl.yml
+++ b/ansible-scripts/maintenance/update_ibp_ssl.yml
@@ -56,5 +56,5 @@
   remote_user: ansible
   become: yes
   tasks:
-    - name: Restart haproxy
+    - name: Reload haproxy
       service: name=haproxy statea=reloaded

--- a/ansible-scripts/maintenance/update_ibp_ssl.yml
+++ b/ansible-scripts/maintenance/update_ibp_ssl.yml
@@ -57,4 +57,4 @@
   become: yes
   tasks:
     - name: Restart haproxy
-      service: name=haproxy state=restarted
+      service: name=haproxy statea=reloaded


### PR DESCRIPTION
Avoids downtime and connection drops associated with restarts by gracefully transferring existing connections to the new process.